### PR TITLE
Remove utc time of the working group meetings

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The list of project contributors and maintainers can be found in [TEAMS.md](TEAM
 
 Working group meetings are a great place to more directly communicate with other members of the community. They tend to discuss active [RFCs](https://github.com/paketo-buildpacks/rfcs) and relay general project information.
 
-These meetings occur bi-weekly on Tuesdays at 2pm EST/EDT (18:00 UTC)
+These meetings occur bi-weekly on Tuesdays at 2pm EST/EDT.
 
 #### Meeting Info
 


### PR DESCRIPTION
With daylight saving time this would currently be at 7pm UTC. Having a wrong date is misleading while updating it twice a year or describing this would be too complicated. 
I thought about linking the date to a website converting it to the users local time but did not want to choose one.
