### PR TITLE
Add stack choices section to the paketo style-guide

### DIFF
--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -24,3 +24,16 @@
    Guide](https://google.github.io/styleguide/shellguide.html) in mind.
    * In particular, check out the "When to use Shell" section to consider if
      it's time to switch languages.
+
+## Stack choice
+
+Most Paketo buildpacks can be divided into two categories - 
+
+- Dependency/Distribution buildpacks like - [go-dist](https://github.com/paketo-buildpacks/go-dist), [node-engine](https://github.com/paketo-buildpacks/node-engine), [yarn](https://github.com/paketo-buildpacks/yarn), [dep](https://github.com/paketo-buildpacks/dep) etc. which provide tarball distributions which maybe architecture or linux distro specific.
+- Configuration/Utility buildpacks like - [procfile](https://github.com/paketo-buildpacks/procfile), [environment-variables](https://github.com/paketo-buildpacks/environment-variables), [go-mod-vendor](https://github.com/paketo-buildpacks/go-mod-vendor), [npm-install](https://github.com/paketo-buildpacks/npm-install) etc. which use distribution buildpacks or are completely standalone.
+
+1. Whenever possible, we should set the most permissive stack id for a buildpack. The Cloud Native Buildpack [spec](https://github.com/buildpacks/spec/blob/buildpack/0.5/buildpack.md#buildpack-implementations) allows for a wildcard stack `*` which indicates compatibility with any stack. 
+
+1. The wildcard stack should be the stack of choice for utility or configuration buildpacks provided they can work on any linux stack. This should be the case for buildpacks written in `go` that are standalone and don't rely on any implicit stack dependencies.
+
+1. If there are cases where a buildpack may work with any stack, but only under certain conditions, the buildpack should still indicate compatibility with any stack via the `*` stack id and dynamically validate the conditions it would properly execute in during its `detect` or `build` step with the aim being to fail as fast as possible if an incompatible environment is detected.


### PR DESCRIPTION
## Summary
<!-- A short explanation of the proposed change -->

Based on the discussion in the WG meeting on June 8th 2021, adding a style guide section to allow buildpacks to be more permissive about the stacks they work on. This goes along well with the paketo ideology of buildpacks being modular composable pieces.

## Use Cases
<!-- An explanation of the use cases your change enables -->

This would allow a wide range of buildpacks that currently couldn't be used with stacks other than ubuntu bionic to be re-used without any forking necessary.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
