### PR TITLE
Clarify that anyone can participate in the project

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -34,6 +34,116 @@ Each team is additionally responsible for maintaining  relevant documentation at
 
 ### Roles
 
+#### Summary
+
+The following table lists the roles we use within the Paketo community. The table describes:
+
+- General responsibilities expected by individuals in each role
+- Requirements necessary to join or stay in a given role
+- How the role manifests in terms of permissions and privileges.
+
+<table>
+  <thead>
+    <tr>
+    <th>Role</th>
+    <th>Responsibilities</th>
+    <th>Requirements</th>
+    <th>Privileges</th>
+    <th>Scope</th>
+    </tr>
+  </thead>
+
+  <tr>
+    <td>(everyone)</td>
+    <td>None</td>
+    <td>None</td>
+    <td>
+        <p>Can submit PRs and issues</p>
+        <p>Can join CF Slack workspace</p>
+        <p>Can take part in community discussions</p>
+    </td>
+    <td>GitHub Organization</td>
+  </tr>  
+
+  <tr>
+    <td>Member</td>
+    <td>
+        <p>Adheres to code of conduct</p>
+    </td>
+    <td>
+        <p>Signed CLA (only for PRs)</p>
+    </td>
+    <td>
+        <p>Can get PRs accepted</p>
+    </td>
+    <td>GitHub Organization</td>
+  </tr>
+
+  <tr>
+    <td rowspan="2">Contributor</td>
+    <td colspan="4"><i>Inherits from Member Role</i></td>
+  </tr>
+  <tr>
+    <td>
+        <p>Regular active contributor in the community</p>
+        <p>Triage issues in their subteam</p>
+    </td>
+    <td>
+        <p>Has made multiple contributions to the project</p>
+    </td>
+    <td>
+        <p>Member of the GitHub paketo-buildpacks (and possibly the paketo-community) orgs</p>
+        <p>Member of the Paketo Slack workspace</p>
+        <p>May review, approve PRs (non-binding), and merge approved PRs.</p>
+        <p>May create branches</p>
+    </td>
+    <td>Paketo Subteam</td>
+  </tr>
+
+  <tr>
+  <tr>
+    <td rowspan="2">Maintainer</td>
+    <td colspan="4"><i>Inherits from Contributor Role</i></td>
+  </tr>
+  <tr>
+    <td>
+        <p>Review and approve (binding) PRs</p>
+        <p>Ensure contributions align with project goals and meet the project's quality standards</p>
+        <p>Provide direction and set goals for their subteam</p>
+        <p>Mentor new contributors</p>
+    </td>
+    <td>
+        <p>Must be an existing contributor</p>
+        <p>Highly experienced and active reviewer and contributor to an area</p>
+    </td>
+    <td>
+        <p>Can merge PRs</p>
+        <p>May vote on RFCS that affect their subteams</p>
+    </td>
+    <td>Paketo Subteam</td>
+  </tr>
+
+  <tr>
+    <td rowspan="2">Steering Committee</td>
+    <td colspan="4"><i>Inherits from Maintainer Role</i></td>
+  </tr>
+  <tr>
+    <td>
+        <p>Set priorities and roadmap for the project</p>
+        <p>Mentor new contributors and maintainers</p>
+        <p>Vote on governace, role, RFCs, and other project-wide changes</p>
+    </td>
+    <td>
+        <p>Must be an existing maintainer</p>
+        <p>Highly active maintainer and participant in multiple functional areas</p>
+    </td>
+    <td>
+        <p>Org-wide permissions</p>
+    </td>
+    <td>Github Org</td>
+  </tr>
+</table>
+
 #### Everyone
 You do not need to be a member of the Paketo team to help. Anyone can help by using and talking about Paketo Buildpacks, participating in discussions, answering questions on Slack/Stack Overflow, opening issues, submitting PRs, etc... All of these are fantastic and welcome contributions to the community.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -34,7 +34,10 @@ Each team is additionally responsible for maintaining  relevant documentation at
 
 ### Roles
 
-#### Contributor:
+#### Everyone
+You do not need to be a member of the Paketo team to help. Anyone can help by using and talking about Paketo Buildpacks, participating in discussions, answering questions on Slack/Stack Overflow, opening issues, submitting PRs, etc... All of these are fantastic and welcome contributions to the community.
+
+#### Contributor
 Contributors are those who make regular contributions to the project (documentation, code reviews, responding to issues, participation in proposal discussions, contributing code, etc.). 
 
 New contributors may be self-nominated or nominated by existing contributors, and must be elected by a supermajority of that project’s maintainers. Contributors may review and approve PRs (non-binding), merge approved PRs, and create branches.


### PR DESCRIPTION
Adds an "Everyone" role to try and clarify that you do not need to be a "contributor" to contribute. It's just a perhaps unfortunate choice for the name of the role we've chosen for folks that regularly participate in the Paketo projects. Everyone can contribute, those with the contributor role contribute a lot.

Resolves #84
