### PR TITLE
Add simplified format of ADOPTERS list

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,33 +1,15 @@
 # Paketo Buildpacks Adopters
 
-If you're using Paketo Buildpacks and want to add your organization to this list, just add a response to [this Discussion](https://github.com/paketo-buildpacks/feedback/discussions/30) and we'll get your organization added.
+Below is a list of projects and organizations that have publicly adopted Paketo Buildpacks:
 
-If you want to add it yourself, please follow [these directions](#adding-your-organization-to-the-list-of-paketo-buildpacks-adopters).
-
-
-## Success Stories
-
-Below is a list of adopters of Paketo Buildpacks in **production environments** that have
-publicly shared the details of how they use it.
-
-*Your org/project here*
-## Solutions built with Paketo Buildpacks
-
-Below is a list of solutions where Paketo Buildpacks are being used as a component:   
-
-<a href="https://www.knative.dev" border="0" target="_blank"><img alt="knative.dev" src="img/adopters/knative-logo-rgb.png" height="50"></a>&nbsp; &nbsp; &nbsp;  
 [Knative](https://knative.dev/)   
+
 Paketo buildpacks serve as the default method of converting a Knative function into an OCI container for deployment. The [func CLI](https://github.com/knative-sandbox/kn-plugin-func) uses the pack Go library to programatically invoke a build, potentially applying additional buildpacks when doing so.
 
 *Your project/solution here*
 
 ## Adding your organization to the list of Paketo Buildpacks Adopters
-
-* Add a link to your company/organization home page, documentation site or product announcement which directly mentions the usage of Paketo Buildpacks. 
-* Include a brief description of how your organization is using Paketo.
-* Add an SVG/PNG version of your logo to the `/img/adopters` directory in this repo and submit a [pull request](https://github.com/paketo-buildpacks/community/pulls) with your change.   
-* Name the image file something that reflects your company (e.g., if your company is called Acme, name the image acme.png)    
-
-
-
-
+There are two ways to do so:
+  * Add a comment to [this Discussion](https://github.com/paketo-buildpacks/feedback/discussions/30) including a brief description of your use case
+   OR
+  * Open a PR adding yourself to `ADOPTERS.md` 


### PR DESCRIPTION
Signed-off-by: David Espejo <daespejo@vmware.com>


## Summary
This change has the goal of making it easier for orgs/companies to get added to ADOPTERS, removing logo requirements and focusing on the Paketo Buildpacks use case

See [this thread ](https://paketobuildpacks.slack.com/archives/C011S6EL49L/p1659567305811369)for more context