### PR TITLE
Add Bloomberg to the list of adopters

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,18 +1,18 @@
 # Paketo Buildpacks Adopters
 
-Below is a list of projects and organizations that have publicly adopted Paketo Buildpacks:
+Below is a list of organizations and projects that have publicly adopted Paketo Buildpacks:
 
-[Fly.io](https://fly.io/docs/reference/builders/#buildpacks)   
+<!-- Add an entry for your organization making sure to preserve the alphabetical order -->
 
-Paketo is one of the buildpacks options that Fly users can select from in `flyctl`. An example using the Go buildpack is available in the [documentation](https://fly.io/docs/getting-started/golang/#inside-fly-toml)   
-[Knative](https://knative.dev/)   
+| Organization/Project | Description |
+| --- | --- |
+| [Bloomberg](https://www.bloomberg.com/company/values/tech-at-bloomberg/open-source/projects/#developer-workflow) | Bloomberg uses Paketo-based buildpacks for its internal platforms. |
+| [Fly.io](https://fly.io/docs/reference/builders/#buildpacks) | Paketo is one of the buildpacks options that Fly users can select from in `flyctl`. An example using the Go buildpack is available in the [documentation](https://fly.io/docs/getting-started/golang/#inside-fly-toml)  | 
+| [Knative](https://knative.dev/) | Paketo buildpacks serve as the default method of converting a Knative function into an OCI container for deployment. The [func CLI](https://github.com/knative-sandbox/kn-plugin-func) uses the pack Go library to programatically invoke a build, potentially applying additional buildpacks when doing so. |
 
-Paketo buildpacks serve as the default method of converting a Knative function into an OCI container for deployment. The [func CLI](https://github.com/knative-sandbox/kn-plugin-func) uses the pack Go library to programatically invoke a build, potentially applying additional buildpacks when doing so.
-
-*Your project/solution here*
 
 ## Adding your organization to the list of Paketo Buildpacks Adopters
 There are two ways to do so:
   * Add a comment to [this Discussion](https://github.com/paketo-buildpacks/feedback/discussions/30) including a brief description of your use case
    OR
-  * Open a PR adding yourself to `ADOPTERS.md` 
+  * Open a PR adding yourself to `ADOPTERS.md`


### PR DESCRIPTION
Bloomberg uses Paketo as noted in https://www.bloomberg.com/company/values/tech-at-bloomberg/open-source/projects/#developer-workflow

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary

Add Bloomberg to the list of adopters and improve the organization of the ADOPTERS.md file.

[Readable](https://github.com/samj1912/community-1/blob/patch-1/ADOPTERS.md)

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
