### PR TITLE
Propose changes to contributor ladder/roles in GOVERNANCE

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -54,8 +54,8 @@ The following table lists the roles we use within the Paketo community. The tabl
   </thead>
 
   <tr>
-    <td>(everyone)</td>
-    <td>None</td>
+    <td>Community participant</td>
+    <td>Follow the CFF Code of Conduct</td>
     <td>None</td>
     <td>
         <p>Can submit PRs and issues</p>
@@ -64,24 +64,9 @@ The following table lists the roles we use within the Paketo community. The tabl
     </td>
     <td>GitHub Organization</td>
   </tr>  
-
-  <tr>
-    <td>Member</td>
-    <td>
-        <p>Adheres to code of conduct</p>
-    </td>
-    <td>
-        <p>Signed CLA (only for PRs)</p>
-    </td>
-    <td>
-        <p>Can get PRs accepted</p>
-    </td>
-    <td>GitHub Organization</td>
-  </tr>
-
   <tr>
     <td rowspan="2">Contributor</td>
-    <td colspan="4"><i>Inherits from Member Role</i></td>
+    <td colspan="4"><i>Inherits from Community participant Role</i></td>
   </tr>
   <tr>
     <td>
@@ -99,12 +84,11 @@ The following table lists the roles we use within the Paketo community. The tabl
     </td>
     <td>Paketo Subteam</td>
   </tr>
-
-  <tr>
-  <tr>
+<tr>
     <td rowspan="2">Maintainer</td>
     <td colspan="4"><i>Inherits from Contributor Role</i></td>
   </tr>
+ 
   <tr>
     <td>
         <p>Review and approve (binding) PRs</p>
@@ -144,7 +128,7 @@ The following table lists the roles we use within the Paketo community. The tabl
   </tr>
 </table>
 
-#### Everyone
+#### Community participant
 You do not need to be a member of the Paketo team to help. Anyone can help by using and talking about Paketo Buildpacks, participating in discussions, answering questions on Slack/Stack Overflow, opening issues, submitting PRs, etc... All of these are fantastic and welcome contributions to the community.
 
 #### Contributor


### PR DESCRIPTION
Signed-off-by: David Espejo <daespejo@vmware.com>

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
As part of an initial discusion on [Slack](https://paketobuildpacks.slack.com/archives/C011S6EL49L/p1664389657343399), the current role definitions in GOVERNANCE would imply that a community member:

1. Could take part in community discussions without being required to adhere to the Code of Conduct
2. Would need to be granted Member role to get PRs accepted (chicken/egg problem)

This PR takes inspiration from the CNCF [Contributor Ladder template](https://github.com/cncf/project-template/blob/main/CONTRIBUTOR_LADDER.md) to propose changes aimed to streamline and clarify the path to maintainership

No changes to Responsibilities, Requirements nor Privileges for Contributor role and above. Also the removal of the `Member` role is proposed

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
