### PR TITLE
Adding Apcoa to Paketo adoptors list

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -13,7 +13,7 @@ Below is a list of organizations and projects that have publicly adopted Paketo 
 | [Knative](https://knative.dev/) | Paketo buildpacks serve as the default method of converting a Knative function into an OCI container for deployment. The [func CLI](https://github.com/knative-sandbox/kn-plugin-func) uses the pack Go library to programatically invoke a build, potentially applying additional buildpacks when doing so. |
 |[Porter](https://docs.porter.run/deploying-applications/deploying-from-github/selecting-application-and-build-method/#customizing-buildpacks)|Porter supports Paketo buildpacks as an option for users to build and deploy their applications on Kubernetes without having to manually containerize them|
 |[Randoli](https://randoli.ca/app-director/) | Randoli's App Director users can choose Paketo buildpacks to containerize their applications and then deploy them to any Kubernetes cluster straight from the UI |
-|[Apcoa](https://urban-hubs.apcoa.com/) | Apcoa urban hubs uses paketo buildpacks for cloud native services to support different mobility needs. We are looking to expand our use of buildpacks with different type of functions and services used in our cloud platform.
+|[Apcoa](https://urban-hubs.apcoa.com/) | Apcoa urban hubs uses paketo buildpacks for cloud native services to support different mobility needs. We are looking to expand our use of buildpacks with different type of functions and services used in our cloud platform. 
 
 ## Adding your organization to the list of Paketo Buildpacks Adopters
 There are two ways to do so:

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -13,7 +13,7 @@ Below is a list of organizations and projects that have publicly adopted Paketo 
 | [Knative](https://knative.dev/) | Paketo buildpacks serve as the default method of converting a Knative function into an OCI container for deployment. The [func CLI](https://github.com/knative-sandbox/kn-plugin-func) uses the pack Go library to programatically invoke a build, potentially applying additional buildpacks when doing so. |
 |[Porter](https://docs.porter.run/deploying-applications/deploying-from-github/selecting-application-and-build-method/#customizing-buildpacks)|Porter supports Paketo buildpacks as an option for users to build and deploy their applications on Kubernetes without having to manually containerize them|
 |[Randoli](https://randoli.ca/app-director/) | Randoli's App Director users can choose Paketo buildpacks to containerize their applications and then deploy them to any Kubernetes cluster straight from the UI |
-|[Apcoa](https://urban-hubs.apcoa.com/) | Apcoa urban hubs uses paketo buildpacks for cloud native services to support different mobility needs. We are looking to expand our use of buildpacks with different type of functions and services used in our cloud platform. 
+|[Apcoa](https://urban-hubs.apcoa.com/) | Apcoa urban hubs uses paketo buildpacks for cloud native services to support different mobility needs. We are looking to expand our use of buildpacks with different type of functions and services used in our cloud platform. |
 
 ## Adding your organization to the list of Paketo Buildpacks Adopters
 There are two ways to do so:

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -13,7 +13,7 @@ Below is a list of organizations and projects that have publicly adopted Paketo 
 | [Knative](https://knative.dev/) | Paketo buildpacks serve as the default method of converting a Knative function into an OCI container for deployment. The [func CLI](https://github.com/knative-sandbox/kn-plugin-func) uses the pack Go library to programatically invoke a build, potentially applying additional buildpacks when doing so. |
 |[Porter](https://docs.porter.run/deploying-applications/deploying-from-github/selecting-application-and-build-method/#customizing-buildpacks)|Porter supports Paketo buildpacks as an option for users to build and deploy their applications on Kubernetes without having to manually containerize them|
 |[Randoli](https://randoli.ca/app-director/) | Randoli's App Director users can choose Paketo buildpacks to containerize their applications and then deploy them to any Kubernetes cluster straight from the UI |
-
+|[Apcoa](https://urban-hubs.apcoa.com/) | Apcoa urban hubs uses paketo buildpacks for cloud native services to support different mobility needs. We are looking to expand our use of buildpacks with different type of functions and services used in our cloud platform.
 
 ## Adding your organization to the list of Paketo Buildpacks Adopters
 There are two ways to do so:


### PR DESCRIPTION
## Summary
Adding Apcoa to Paketo buildpacks adopter list. 

## Use Cases
We are using paketo buildpacks for all of our cloud native services for urban mobility hub use cases https://urban-hubs.apcoa.at/

## Checklist
 * [x] I have viewed, signed, and submitted the Contributor License Agreement.
 * [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
 * [x] I have added an integration test, if necessary.
 * [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
 * [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
