### PR TITLE
Make steering committee memebers co-owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-*              @paketo-buildpacks/content-maintainers
-GOVERNANCE.md  @paketo-buildpacks/steering-committee
+*              @paketo-buildpacks/content-maintainers @paketo-buildpacks/steering-committee


### PR DESCRIPTION
## Summary

Allows @paketo-buildpacks/steering-committee to be co-owners of this repository.

## Use Cases

Steering Committee members often are the ones managing these files. It helps if we can review & merge.
